### PR TITLE
Fix Python errors reported by flake8

### DIFF
--- a/nvmesh_telegraf.py
+++ b/nvmesh_telegraf.py
@@ -47,127 +47,154 @@ REGEX_DISK_WRITE_LATENCY = r"\bwrite_latency=(\d*.\d*)"
 
 
 def collect_volume_stats():
-  telegraf_line_protocol_output = ""
+    telegraf_line_protocol_output = ""
 
-  for _,dirs,_ in os.walk(VOLUMES_ROOT):
+    for _, dirs, _ in os.walk(VOLUMES_ROOT):
 
-    for volume in dirs:
+        for volume in dirs:
 
-      try:
-        with open(VOLUMES_ROOT + volume + '/iostats', 'r') as file_object:
-          iostats = file_object.read()
+            try:
+                with open(
+                        VOLUMES_ROOT + volume + '/iostats', 'r'
+                        ) as file_object:
+                    iostats = file_object.read()
 
-          telegraf_output_line = "nvmesh,volume=" + volume
+                    telegraf_output_line = "nvmesh,volume=" + volume
 
-          num_ops = re.findall(REGEX_VOL_NUM_OPS, iostats)
-          if len(num_ops) == 1 and len(num_ops[0]) >= 2:
-            telegraf_output_line += ' num_ops_read=' + num_ops[0][0].strip()
-            telegraf_output_line += ',num_ops_write=' + num_ops[0][1].strip()
+                    num_ops = re.findall(REGEX_VOL_NUM_OPS, iostats)
+                    if len(num_ops) == 1 and len(num_ops[0]) >= 2:
+                        telegraf_output_line += ' num_ops_read=' + \
+                            num_ops[0][0].strip()
+                        telegraf_output_line += ',num_ops_write=' + \
+                            num_ops[0][1].strip()
 
-          size_in_bytes = re.findall(REGEX_VOL_SIZE_IN_BYTES, iostats)
-          if len(size_in_bytes) == 1 and len(size_in_bytes[0]) >= 2:
-            telegraf_output_line += ',size_in_bytes_read=' + size_in_bytes[0][0].strip()
-            telegraf_output_line += ',size_in_bytes_write=' + size_in_bytes[0][1].strip()
+                    size_in_bytes = re.findall(
+                        REGEX_VOL_SIZE_IN_BYTES, iostats)
+                    if len(size_in_bytes) == 1 and len(size_in_bytes[0]) >= 2:
+                        telegraf_output_line += ',size_in_bytes_read=' + \
+                            size_in_bytes[0][0].strip()
+                        telegraf_output_line += ',size_in_bytes_write=' + \
+                            size_in_bytes[0][1].strip()
 
-          latency = re.findall(REGEX_VOL_LATENCY, iostats)
-          if len(latency) == 1 and len(latency[0]) >= 2:
-            telegraf_output_line += ',latency_read=' + latency[0][0].strip()
-            telegraf_output_line += ',latency_write=' + latency[0][1].strip()
+                    latency = re.findall(REGEX_VOL_LATENCY, iostats)
+                    if len(latency) == 1 and len(latency[0]) >= 2:
+                        telegraf_output_line += ',latency_read=' + \
+                            latency[0][0].strip()
+                        telegraf_output_line += ',latency_write=' + \
+                            latency[0][1].strip()
 
-          telegraf_line_protocol_output += telegraf_output_line + '\n'
-      except:
-        pass
+                    telegraf_line_protocol_output += telegraf_output_line + \
+                        '\n'
+            except BaseException:
+                pass
 
-  return telegraf_line_protocol_output
+    return telegraf_line_protocol_output
 
 
 def collect_disk_stats13():
-  telegraf_line_protocol_output = ""
+    telegraf_line_protocol_output = ""
 
-  for _, dirs, _ in os.walk(DISK_ROOT):
+    for _, dirs, _ in os.walk(DISK_ROOT):
 
-    for disk in dirs:
-      try:
-        diskstats = DISK_ROOT + disk + '/stats'
-        with open(diskstats, 'r') as file_object:
-          stats = file_object.read()
-          telegraf_output_line = "nvmesh,disk=" + disk
+        for disk in dirs:
+            try:
+                diskstats = DISK_ROOT + disk + '/stats'
+                with open(diskstats, 'r') as file_object:
+                    stats = file_object.read()
+                    telegraf_output_line = "nvmesh,disk=" + disk
 
-          disk_reads = re.findall(REGEX_DISK_READ_OPS, stats)
-          if len(disk_reads) == 1:
-                  telegraf_output_line += ' disk_reads=' + disk_reads[0].strip()
+                    disk_reads = re.findall(REGEX_DISK_READ_OPS, stats)
+                    if len(disk_reads) == 1:
+                        telegraf_output_line += ' disk_reads=' + \
+                            disk_reads[0].strip()
 
-          disk_writes = re.findall(REGEX_DISK_WRITE_OPS, stats)
-          if len(disk_writes) == 1:
-            telegraf_output_line += ',disk_writes=' + disk_writes[0].strip()
+                    disk_writes = re.findall(REGEX_DISK_WRITE_OPS, stats)
+                    if len(disk_writes) == 1:
+                        telegraf_output_line += ',disk_writes=' + \
+                            disk_writes[0].strip()
 
-          read_in_bytes = re.findall(REGEX_DISK_READ_SIZE, stats)
-          if len(read_in_bytes) == 1:
-            telegraf_output_line += ',disk_read_in_bytes=' + read_in_bytes[0].strip()
+                    read_in_bytes = re.findall(REGEX_DISK_READ_SIZE, stats)
+                    if len(read_in_bytes) == 1:
+                        telegraf_output_line += ',disk_read_in_bytes=' + \
+                            read_in_bytes[0].strip()
 
-          write_in_bytes = re.findall(REGEX_DISK_WRITE_SIZE, stats)
-          if len(write_in_bytes) == 1:
-            telegraf_output_line += ',disk_write_in_bytes=' + write_in_bytes[0].strip()
+                    write_in_bytes = re.findall(REGEX_DISK_WRITE_SIZE, stats)
+                    if len(write_in_bytes) == 1:
+                        telegraf_output_line += ',disk_write_in_bytes=' + \
+                            write_in_bytes[0].strip()
 
-          latency_read = re.findall(REGEX_DISK_READ_LATENCY, stats)
-          if len(latency_read) == 1:
-            telegraf_output_line += ',disk_read_latency=' + latency_read[0].strip()
+                    latency_read = re.findall(REGEX_DISK_READ_LATENCY, stats)
+                    if len(latency_read) == 1:
+                        telegraf_output_line += ',disk_read_latency=' + \
+                            latency_read[0].strip()
 
-          latency_write = re.findall(REGEX_DISK_WRITE_LATENCY, stats)
-          if len(latency_write) == 1:
-            telegraf_output_line += ',disk_write_latency=' + latency_write[0].strip()
+                    latency_write = re.findall(REGEX_DISK_WRITE_LATENCY, stats)
+                    if len(latency_write) == 1:
+                        telegraf_output_line += ',disk_write_latency=' + \
+                            latency_write[0].strip()
 
-          telegraf_line_protocol_output += telegraf_output_line + '\n'
-      except:
-        pass
+                    telegraf_line_protocol_output += telegraf_output_line + \
+                        '\n'
+            except BaseException:
+                pass
 
-  return telegraf_line_protocol_output
+    return telegraf_line_protocol_output
+
 
 def collect_disk_stats2():
-  telegraf_line_protocol_output = ""
+    telegraf_line_protocol_output = ""
 
-  for _, dirs, _ in os.walk(DISK_ROOT):
+    for _, dirs, _ in os.walk(DISK_ROOT):
 
-    for disk in dirs:
-      try:
-        diskstats = DISK_ROOT + disk + '/iostats'
-        with open(diskstats, 'r') as file_object:
-          stats = file_object.read()
-          telegraf_output_line = "nvmesh,disk=" + disk
+        for disk in dirs:
+            try:
+                diskstats = DISK_ROOT + disk + '/iostats'
+                with open(diskstats, 'r') as file_object:
+                    stats = file_object.read()
+                    telegraf_output_line = "nvmesh,disk=" + disk
 
-          disk_reads = re.findall(REGEX_DISK_READ_OPS, stats)
-          if len(disk_reads) == 1:
-                  telegraf_output_line += ' disk_reads=' + disk_reads[0].strip()
+                    disk_reads = re.findall(REGEX_DISK_READ_OPS, stats)
+                    if len(disk_reads) == 1:
+                        telegraf_output_line += ' disk_reads=' + \
+                            disk_reads[0].strip()
 
-          disk_writes = re.findall(REGEX_DISK_WRITE_OPS, stats)
-          if len(disk_writes) == 1:
-            telegraf_output_line += ',disk_writes=' + disk_writes[0].strip()
+                    disk_writes = re.findall(REGEX_DISK_WRITE_OPS, stats)
+                    if len(disk_writes) == 1:
+                        telegraf_output_line += ',disk_writes=' + \
+                            disk_writes[0].strip()
 
-          read_in_bytes = re.findall(REGEX_DISK_READ_SIZE, stats)
-          if len(read_in_bytes) == 1:
-            telegraf_output_line += ',disk_read_in_bytes=' + read_in_bytes[0].strip()
+                    read_in_bytes = re.findall(REGEX_DISK_READ_SIZE, stats)
+                    if len(read_in_bytes) == 1:
+                        telegraf_output_line += ',disk_read_in_bytes=' + \
+                            read_in_bytes[0].strip()
 
-          write_in_bytes = re.findall(REGEX_DISK_WRITE_SIZE, stats)
-          if len(write_in_bytes) == 1:
-            telegraf_output_line += ',disk_write_in_bytes=' + write_in_bytes[0].strip()
+                    write_in_bytes = re.findall(REGEX_DISK_WRITE_SIZE, stats)
+                    if len(write_in_bytes) == 1:
+                        telegraf_output_line += ',disk_write_in_bytes=' + \
+                            write_in_bytes[0].strip()
 
-          latency_read = re.findall(REGEX_DISK_READ_LATENCY, stats)
-          if len(latency_read) == 1:
-            telegraf_output_line += ',disk_read_latency=' + latency_read[0].strip()
+                    latency_read = re.findall(REGEX_DISK_READ_LATENCY, stats)
+                    if len(latency_read) == 1:
+                        telegraf_output_line += ',disk_read_latency=' + \
+                            latency_read[0].strip()
 
-          latency_write = re.findall(REGEX_DISK_WRITE_LATENCY, stats)
-          if len(latency_write) == 1:
-            telegraf_output_line += ',disk_write_latency=' + latency_write[0].strip()
+                    latency_write = re.findall(REGEX_DISK_WRITE_LATENCY, stats)
+                    if len(latency_write) == 1:
+                        telegraf_output_line += ',disk_write_latency=' + \
+                            latency_write[0].strip()
 
-          telegraf_line_protocol_output += telegraf_output_line + '\n'
-      except:
-        pass
+                    telegraf_line_protocol_output += telegraf_output_line + \
+                        '\n'
+            except BaseException:
+                pass
 
-  return telegraf_line_protocol_output
+    return telegraf_line_protocol_output
+
 
 def collect_disk_stats():
     return collect_disk_stats13() + collect_disk_stats2()
 
+
 if __name__ == "__main__":
 
-  print ("%s%s") % (collect_volume_stats(), collect_disk_stats())
+    print("%s%s") % (collect_volume_stats(), collect_disk_stats())


### PR DESCRIPTION
Some errors are reported on the python script when running flake8.

```
$ flake8 nvmesh_telegraf.py 
nvmesh_telegraf.py:50:3: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:52:3: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:52:8: E231 missing whitespace after ','
nvmesh_telegraf.py:52:13: E231 missing whitespace after ','
nvmesh_telegraf.py:56:7: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:58:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:60:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:62:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:63:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:67:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:68:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:69:80: E501 line too long (88 > 79 characters)
nvmesh_telegraf.py:70:80: E501 line too long (89 > 79 characters)
nvmesh_telegraf.py:72:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:73:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:77:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:78:7: E722 do not use bare 'except'
nvmesh_telegraf.py:78:7: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:81:3: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:85:3: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:87:3: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:90:7: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:93:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:94:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:96:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:97:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:98:19: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:98:19: E117 over-indented
nvmesh_telegraf.py:98:80: E501 line too long (80 > 79 characters)
nvmesh_telegraf.py:100:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:101:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:104:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:105:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:106:80: E501 line too long (85 > 79 characters)
nvmesh_telegraf.py:108:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:109:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:110:80: E501 line too long (87 > 79 characters)
nvmesh_telegraf.py:112:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:113:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:114:80: E501 line too long (83 > 79 characters)
nvmesh_telegraf.py:116:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:117:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:118:80: E501 line too long (85 > 79 characters)
nvmesh_telegraf.py:120:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:121:7: E722 do not use bare 'except'
nvmesh_telegraf.py:121:7: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:124:3: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:126:1: E302 expected 2 blank lines, found 1
nvmesh_telegraf.py:127:3: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:129:3: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:132:7: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:135:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:136:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:138:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:139:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:140:19: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:140:19: E117 over-indented
nvmesh_telegraf.py:140:80: E501 line too long (80 > 79 characters)
nvmesh_telegraf.py:142:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:143:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:146:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:147:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:148:80: E501 line too long (85 > 79 characters)
nvmesh_telegraf.py:150:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:151:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:152:80: E501 line too long (87 > 79 characters)
nvmesh_telegraf.py:154:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:155:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:156:80: E501 line too long (83 > 79 characters)
nvmesh_telegraf.py:158:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:159:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:160:80: E501 line too long (85 > 79 characters)
nvmesh_telegraf.py:162:11: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:163:7: E722 do not use bare 'except'
nvmesh_telegraf.py:163:7: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:166:3: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:168:1: E302 expected 2 blank lines, found 1
nvmesh_telegraf.py:171:1: E305 expected 2 blank lines after class or function definition, found 1
nvmesh_telegraf.py:173:3: E111 indentation is not a multiple of 4
nvmesh_telegraf.py:173:8: E211 whitespace before '('
```